### PR TITLE
prebuild performance improvements

### DIFF
--- a/scripts/prebuild.sh
+++ b/scripts/prebuild.sh
@@ -19,6 +19,34 @@ if [[ -n "$PLATFORM" && "$PLATFORM" != "android" && "$PLATFORM" != "ios" ]]; the
   exit 1
 fi
 
+# Determine platforms, defaulting to both if missing/unreadable
+PLATFORMS=("ios" "android")
+PLATFORMS_RAW=$(node -e '
+  try {
+    const fs = require("fs");
+    const cfg = JSON.parse(fs.readFileSync("app.json", "utf8"));
+    const p = (cfg && cfg.expo && cfg.expo.platforms) || cfg.platforms;
+    if (Array.isArray(p)) {
+      console.log(p.filter(Boolean).join(","));
+    }
+  } catch (e) {
+    // fall back to default
+  }
+' 2>/dev/null || true)
+
+if [[ -n "$PLATFORMS_RAW" ]]; then
+  IFS=',' read -r -a PLATFORMS <<< "$PLATFORMS_RAW"
+fi
+
+# If a single platform was requested, ensure it's enabled and then narrow to it
+if [[ -n "$PLATFORM" ]]; then
+  if [[ ! " ${PLATFORMS[*]} " =~ ${PLATFORM} ]]; then
+    echo "Error: Platform '$PLATFORM' is not enabled in app.json. Enabled platforms: ${PLATFORMS[*]}"
+    exit 1
+  fi
+  PLATFORMS=("$PLATFORM")
+fi
+
 # Clean native projects
 rm -rf android ios
 
@@ -26,17 +54,23 @@ rm -rf android ios
 ./scripts/compile-plugins.sh
 
 # Prebuild native projects
-if [[ -z "$PLATFORM" || "$PLATFORM" == "android" ]]; then
+# If android is among enabled platforms
+if [[ " ${PLATFORMS[*]} " =~ android ]]; then
   npx expo prebuild --platform android
 fi
 
-if [[ -z "$PLATFORM" || "$PLATFORM" == "ios" ]]; then
+# If iOS is among enabled platforms
+if [[ " ${PLATFORMS[*]} " =~ ios ]]; then
   npx expo prebuild --platform ios --no-install
   
   # Needed for Ruby v3
   export RUBY_TCP_NO_FAST_FALLBACK=1
 
+  # Install Ruby Gems such as Cocoapods (if not already installed)
+  if [[ ! -d vendor ]]; then
+    bundle install
+  fi
+
   # Install the iOS dependencies using Cocoapods
-  bundle install
   bundle exec pod install --repo-update --project-directory=ios
 fi


### PR DESCRIPTION
# Description

<!-- Describe the changes made in this pull request. -->

> [!WARNING]
> (changes generated by GPT-5)

- evals `"platforms"` Array in `app.json`
  - if you only have `"platforms": ["android"]` we skip anything to do with iOS
  - if you explicitly specify a platform like `./scripts/prebuild.sh --platform ios` it has to be included in `app.json` or the script will error
- additionally, we now only do `bundle install` if we don't already have a `/vendor` directory
  - the Ruby Gems are unlikely to change frequently, so this speeds up consecutive `./scripts/prebuild.sh` runs
  - note that `/vendor` is wiped out by `./scripts/init.sh` so Gems will now only be re-installed when doing a full `./scripts/init.sh` run

## GIF

<!-- Post a tangentially-relevant GIF here. This step is required. -->

![sonic-run](https://github.com/user-attachments/assets/75a49cde-6422-4067-9614-4e871c95d1a0)
