### PR TITLE
update PR Checks after choosing yarn

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -2,7 +2,7 @@
 set -e  # Exit on error
 
 # Clean project
-rm -rf .expo android ios node_modules vendor
+rm -rf .expo dist android ios node_modules vendor
 
 # Install dependencies
 ./scripts/install-dependencies.sh

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -22,3 +22,11 @@ fi
 # Install dependencies
 echo "Running '$PACKAGE_MANAGER install' in ${PWD}"
 $PACKAGE_MANAGER install
+
+# Update PR Checks GitHub Action if required
+if [ "$PACKAGE_MANAGER" = "yarn" ]; then
+    sed -i '' 's/cache: npm/cache: yarn/g' .github/workflows/PR\ Checks.yml
+    sed -i '' 's/npm install/yarn install/g' .github/workflows/PR\ Checks.yml
+    sed -i '' 's/npm run/yarn/g' .github/workflows/PR\ Checks.yml
+    sed -i '' 's/npx/yarn/g' .github/workflows/PR\ Checks.yml
+fi


### PR DESCRIPTION
# Description

<!-- Describe the changes made in this pull request. -->

This PR adds an extra step to the end of the `install-dependencies.sh` script. If a project has chosen to use Yarn, we should update the `PR Checks.yml` GitHub Action so that dependencies are cached correctly.